### PR TITLE
`TheGoldStandard.version` :congratulations:

### DIFF
--- a/Changelog.cfg
+++ b/Changelog.cfg
@@ -1,13 +1,127 @@
-﻿// Changelog.cfg v1.6.1.0
+﻿// Changelog.cfg v1.6.1.1
 // The Gold Standard (GOLD)
 // created: 2020 02 25
-// updated: 07 Aug 2021
+// updated: 14 Aug 2021
 KERBALCHANGELOG
 {
 	showChangelog = True
 	modName = The Gold Standard
 	license = CC-BY-NC-SA-4.0
 	author = zer0Kerbal
+	VERSION
+	{
+	  version = 1.6.2.1
+	  versionName = Overpriced!
+	  versionDate = 2021-09-14
+	  versionKSP = 1.12.2
+	  change = <b><color=#BADA55>DO A CLEAN INSTALL: DELETE EXISTING THEN RE-INSTALL</color></b>
+	  change = <b>Resources and corresponding tanks have changed density/volume/cost/mass </b>
+	  CHANGE
+	  {
+		type = Release
+		change = for KSP 1.12.2
+		subchange = won't be last release for 1.12.2
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = `TheGoldStandard.version`
+		subChange = had '-' instead of '_'; 
+		subChange = what is up with this graffiti? 
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = Part [cost]
+		subchange = Thank you to @TheKurgan for finding the following:
+		subchange = need to be 'wet' or 'full' price else negative cost in editor
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = Part [entryCost]
+		subchange = some adjusted down, some adjust up.
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = Part [packedVolume]
+		subChange = changed large tank's [packedVolume] from 13333 to 9500
+		subChange = changed small tank's [packedVolume] from 3416 to 2400
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = `StockalikeMiningExpansion.cfg`
+		subChange = removed extra `#` graffiti making the localization tags start with `##`, ran out of whiteout...
+	  }
+	  CHANGE
+		type = Added 
+		subChange = [SMX_3mStackDrill] to StockalikeMiningExpansion.cfg patch [WIP]
+		subChange = increment version to 1.1.0.0
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = `GoldSmelter.cfg`
+		subChange = [resourceOutputName = #autoLOC_8012033] changed to [#GoldSmelter-resourceOutputName =  Gold+Ore]
+		subChange = add small `Ore` tank
+	  }
+	  CHANGE
+	  {
+		type = Update  
+		change = Back end  
+		subChange = update auto JSON
+		subChange = update EL.version to match
+		subChange = update automation to latest version
+		subChange = start working with yaclog-KSP (thank you cineboxandrew!)
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = goldOre in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Gold in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Unobtainium in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Patch linting and file maintenance
+		subChange = minor housekeeping  
+		subChange = patch dusting (mostly removing construction dust (comments)) 
+	  }
+	  CHANGE
+	  {
+		type = Status
+		change = Bug
+		subChange = closes #5 Tank costs 
+		subChange = closes #12 Text issue with SMX - anything remaining isn't a Localization issue
+		subChange = closes #15 Drill patches need updating?
+		subChange = closes #16 Tanks ModuleCargoPart: packedVolume
+		change = Feature
+		subChange = updates #11 us-en.cfg should be complete
+	  }
+	}
 	VERSION
 	{
 	  version = 1.6.2.0

--- a/GameData/TheGoldStandard/Changelog.cfg
+++ b/GameData/TheGoldStandard/Changelog.cfg
@@ -1,13 +1,127 @@
-﻿// Changelog.cfg v1.6.1.0
+﻿// Changelog.cfg v1.6.1.1
 // The Gold Standard (GOLD)
 // created: 2020 02 25
-// updated: 07 Aug 2021
+// updated: 14 Aug 2021
 KERBALCHANGELOG
 {
 	showChangelog = True
 	modName = The Gold Standard
 	license = CC-BY-NC-SA-4.0
 	author = zer0Kerbal
+	VERSION
+	{
+	  version = 1.6.2.1
+	  versionName = Overpriced!
+	  versionDate = 2021-09-14
+	  versionKSP = 1.12.2
+	  change = <b><color=#BADA55>DO A CLEAN INSTALL: DELETE EXISTING THEN RE-INSTALL</color></b>
+	  change = <b>Resources and corresponding tanks have changed density/volume/cost/mass </b>
+	  CHANGE
+	  {
+		type = Release
+		change = for KSP 1.12.2
+		subchange = won't be last release for 1.12.2
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = `TheGoldStandard.version`
+		subChange = had '-' instead of '_'; 
+		subChange = what is up with this graffiti? 
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = Part [cost]
+		subchange = Thank you to @TheKurgan for finding the following:
+		subchange = need to be 'wet' or 'full' price else negative cost in editor
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		changed = Part [entryCost]
+		subchange = some adjusted down, some adjust up.
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = Part [packedVolume]
+		subChange = changed large tank's [packedVolume] from 13333 to 9500
+		subChange = changed small tank's [packedVolume] from 3416 to 2400
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = `StockalikeMiningExpansion.cfg`
+		subChange = removed extra `#` graffiti making the localization tags start with `##`, ran out of whiteout...
+	  }
+	  CHANGE
+		type = Added 
+		subChange = [SMX_3mStackDrill] to StockalikeMiningExpansion.cfg patch [WIP]
+		subChange = increment version to 1.1.0.0
+	  }
+	  CHANGE
+	  {
+		type = Correction
+		change = `GoldSmelter.cfg`
+		subChange = [resourceOutputName = #autoLOC_8012033] changed to [#GoldSmelter-resourceOutputName =  Gold+Ore]
+		subChange = add small `Ore` tank
+	  }
+	  CHANGE
+	  {
+		type = Update  
+		change = Back end  
+		subChange = update auto JSON
+		subChange = update EL.version to match
+		subChange = update automation to latest version
+		subChange = start working with yaclog-KSP (thank you cineboxandrew!)
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = goldOre in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Gold in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Unobtainium in [part.cfg] and [ResourcesGeneric.cfg]
+		subChange = cost
+		subChange = mass
+		subChange = volume (in resource.cfg)
+		subChange = tank size
+	  }
+	  CHANGE
+	  {
+		type = Update
+		change = Patch linting and file maintenance
+		subChange = minor housekeeping  
+		subChange = patch dusting (mostly removing construction dust (comments)) 
+	  }
+	  CHANGE
+	  {
+		type = Status
+		change = Bug
+		subChange = closes #5 Tank costs 
+		subChange = closes #12 Text issue with SMX - anything remaining isn't a Localization issue
+		subChange = closes #15 Drill patches need updating?
+		subChange = closes #16 Tanks ModuleCargoPart: packedVolume
+		change = Feature
+		subChange = updates #11 us-en.cfg should be complete
+	  }
+	}
 	VERSION
 	{
 	  version = 1.6.2.0

--- a/GameData/TheGoldStandard/TheGoldStandard.version
+++ b/GameData/TheGoldStandard/TheGoldStandard.version
@@ -2,39 +2,39 @@
 	"NAME"		   : "The Gold Standard (GOLD)",
 	"URL"			: "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/TheGoldStandard.version",
 	"DOWNLOAD"	   : "https://github.com/zer0Kerbal/TheGoldStandard/releases/latest",
-	"CHANGE-LOG-URL" : "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/Changelog.cfg",
+	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/Changelog.cfg",
 	"GITHUB" :
 	{
 		"USERNAME"		  : "zer0Kerbal",
 		"REPOSITORY"		: "TheGoldStandard",
 		"ALLOW-PRE-RELEASE" : false
 	},
-	"VERSION" :
+	"VERSION" : 
 	{
 		"MAJOR" : 1,
 		"MINOR" : 6,
 		"PATCH" : 2,
-		"BUILD" : 0
+		"BUILD" : 1
 	},
-	"KSP-VERSION" :
+	"KSP_VERSION" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 12,
 		"PATCH" : 2
 	},
-	"KSP-VERSION-MIN" :
+	"KSP_VERSION-MIN" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 3,
 		"PATCH" : 1
 	},
-	"KSP-VERSION-MAX" :
+	"KSP_VERSION-MAX" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 12,
 		"PATCH" : 9999
 	},
-	"INSTALL-LOC" :
+	"INSTALL_LOC" :
 	{
 		"NAME" :		  "TheGoldStandard",
 		"DIRECTORY" :	 "TheGoldStandard"

--- a/TheGoldStandard.version
+++ b/TheGoldStandard.version
@@ -2,39 +2,39 @@
 	"NAME"		   : "The Gold Standard (GOLD)",
 	"URL"			: "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/TheGoldStandard.version",
 	"DOWNLOAD"	   : "https://github.com/zer0Kerbal/TheGoldStandard/releases/latest",
-	"CHANGE-LOG-URL" : "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/Changelog.cfg",
+	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/TheGoldStandard/master/Changelog.cfg",
 	"GITHUB" :
 	{
 		"USERNAME"		  : "zer0Kerbal",
 		"REPOSITORY"		: "TheGoldStandard",
 		"ALLOW-PRE-RELEASE" : false
 	},
-	"VERSION" :
+	"VERSION" : 
 	{
 		"MAJOR" : 1,
 		"MINOR" : 6,
 		"PATCH" : 2,
-		"BUILD" : 0
+		"BUILD" : 1
 	},
-	"KSP-VERSION" :
+	"KSP_VERSION" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 12,
 		"PATCH" : 2
 	},
-	"KSP-VERSION-MIN" :
+	"KSP_VERSION-MIN" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 3,
 		"PATCH" : 1
 	},
-	"KSP-VERSION-MAX" :
+	"KSP_VERSION-MAX" :
 	{
 		"MAJOR" : 1,
 		"MINOR" : 12,
 		"PATCH" : 9999
 	},
-	"INSTALL-LOC" :
+	"INSTALL_LOC" :
 	{
 		"NAME" :		  "TheGoldStandard",
 		"DIRECTORY" :	 "TheGoldStandard"

--- a/json/code.json
+++ b/json/code.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "Code",
  "labelColor": "66ccff",
- "message": "<config> <KSP Part> <Module Manager>",
+ "message": "˂˂config˃˃ ˂˂KSP Part˃˃  ˂˂Module Manager˃˃",
  "color": "darkblue",
  "style": "plastic"
 }

--- a/json/mod.json
+++ b/json/mod.json
@@ -2,7 +2,7 @@
  "schemaVersion": 1,
  "label": "The Gold Standard!",
  "labelColor": "darkgreen",
- "message": "1.6.2.0",
+ "message": "1.6.2.1",
  "color": "orange",
  "style": "plastic"
 }


### PR DESCRIPTION
# Correction
- `TheGoldStandard.version`
  - had '-' instead of '_';
  - what is up with this graffiti?